### PR TITLE
Add solution for HW11 task with star

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,13 +1,18 @@
 [defaults]
 nocows = 1
-inventory = ./my_inv.sh
+## inventory = ./my_inv.sh
+inventory = inventory.gcp.yml
 remote_user = appuser
 private_key_file = ~/.ssh/appuser
 host_key_checking = False
 retry_files_enabled = False
+fact_caching_connection = /tmp/infra_inventory
 
 [inventory]
-enable_plugins = script, auto, yaml, ini
+## enable_plugins = script, auto, yaml, ini
+enable_plugins = gcp_compute
+cache = True
+cache_plugin = yaml
 
 [inventory_plugin_script]
 always_show_stderr = yes

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -3,9 +3,12 @@
   hosts: app
   become: true
   vars:
-    db_host: 10.132.15.198
+    db_host: "{{ hostvars[groups['db'][0]]['networkInterfaces'][0]['networkIP'] }}"
 
   tasks:
+    - name: Show IP address
+      debug:
+        msg: "Internal IP for connect to MongoDB: {{db_host}}"
     - name: Add unit file for Puma
       copy:
         src: files/puma.service

--- a/ansible/inventory.gcp.yml
+++ b/ansible/inventory.gcp.yml
@@ -1,0 +1,22 @@
+plugin: gcp_compute
+auth_kind: serviceaccount
+service_account_file: ~/.ssh/gcp_infra_inventory.json
+zones:
+  - europe-west1-b
+projects:
+  - infra-243222
+
+filters: []
+
+### use hostnames only if we have DNS or SSH alias
+# hostnames:
+#   - name
+
+# generate groups for hosts like tag_reddit_app
+keyed_groups:
+  - prefix: tag
+    separator: '-'
+    key: tags['items']
+groups:
+  app: "'reddit-app' in tags['items']"
+  db: "'reddit-db' in tags['items']"

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "app" {
   count        = "${var.apps_count}"
-  name         = "reddit-${var.apps_env}-app-${count.index+1}"
+  name         = "reddit-app-${count.index+1}-${var.apps_env}"
   machine_type = "g1-small"
   zone         = "${var.zone}"
 

--- a/terraform/modules/db/main.tf
+++ b/terraform/modules/db/main.tf
@@ -1,5 +1,5 @@
 resource "google_compute_instance" "db" {
-  name = "reddit-${var.apps_env}-db"
+  name = "reddit-db-${var.apps_env}"
 
   machine_type = "g1-small"
 


### PR DESCRIPTION
# Выполнено ДЗ №11 дополнительное

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Дополнительно к основному ДЗ (уже было смержено) добавлен плагин gcp_compute (получает информацию из Google Cloud напрямую) и включено кэширование inventory
 - Добавлена дополнительная информация по альтернативным вариантам dynamic inventory - с использование результатов из файла состояния terraform и вариант запуска provisioners напрямую из terraform
 - Сохранение ID проекта в паблике вполне допустимо, но в продуктовых решениях лучше передавать через ENV переменные или использовать vault

## Как запустить проект:
 - Теперь не надо делать никаких дополнительных ручных операций, необходимо просто запустить команды по списку и немного подождать (билдим образы, разворачиваем окружение и деплоим базу и приложение):
``` bash
packer build -var-file=packer/variables.json packer/app.json
packer build -var-file=packer/variables.json packer/db.json

cd terraform/stage && terraform apply
cd ../../ansible && ansible-playbook site.yml
```

## Как проверить работоспособность:
 - Перейти по ссылке http://app_external_ip:9292, где app_external_ip взять из вывода terraform

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания